### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/checkov/a9e84373-3aa5-49a8-938b-0bbe24d37b0c/8701d49c-b032-48d9-ba2e-24253e3c5acc/_apis/work/boardbadge/e63e3b11-d271-419d-ae42-ab66d9187800)](https://dev.azure.com/checkov/a9e84373-3aa5-49a8-938b-0bbe24d37b0c/_boards/board/t/8701d49c-b032-48d9-ba2e-24253e3c5acc/Microsoft.RequirementCategory)
 # Terraform Tuesday! 🌮🌮🌮
 
 This is the repository for my weekly Terraform Tuesday videos on [YouTube](https://www.youtube.com/channel/UCDQ9L4eFHxSh0BM6z-SkZMw). You can find all the videos on this [playlist](https://youtube.com/playlist?list=PLXb5972EMl4BWj8cAq9AZgeKBa2M8_7-y).


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/checkov/a9e84373-3aa5-49a8-938b-0bbe24d37b0c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.